### PR TITLE
Added babel-runtime to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"babel-plugin-transform-runtime": "^6.5",
 		"babel-preset-es2015": "^6.5",
 		"babel-preset-react": "^6.5",
+		"babel-runtime": "^6.3",
 		"react": "^0.14.7",
 		"react-dom": "^0.14.7",
 		"react-server": "^0.0.10",


### PR DESCRIPTION
The project currently uses `babel-plugin-transform-runtime` for code transformation but doesn't include `babel-runtime`, which allows the transformed code to work correctly at runtime.
